### PR TITLE
Include print("DEBUG") explicitly

### DIFF
--- a/parsons/local_server.py
+++ b/parsons/local_server.py
@@ -49,7 +49,7 @@ def parsons(problem_name, code_skeleton=False):
     language = problem_config.get('language', 'python')
 
     code_lines = problem_config['code_lines'] + \
-             '\ndebug(!BLANK)' * 2 + '\n# !BLANK' * 2
+             '\nprint(\'DEBUG:\', !BLANK)' * 2 + '\n# !BLANK' * 2
     repr_fname = f'{PARSONS_FOLDER_PATH}/{names_to_paths[problem_name]}{PARSONS_REPR_SUFFIX}'
     if os.path.exists(repr_fname):
         with open(repr_fname, "r") as f:


### PR DESCRIPTION
It's actually a larger change to import ucb into all 61A assignments and complicates our PR over there. Instead of offering a debug wrapper, we can just include print('DEBUG', ____) and that works just fine.

Test change on lab01 locally

<img width="912" alt="Screen Shot 2022-01-16 at 9 37 05 PM" src="https://user-images.githubusercontent.com/297042/149713614-38065efe-a768-4f23-91ca-1326b17cfe04.png">

