### PR TITLE
Remove prettify

### DIFF
--- a/parsons/templates/index.html
+++ b/parsons/templates/index.html
@@ -1,9 +1,7 @@
 {% extends 'base.html' %}
 {% block css %}
     <link rel="stylesheet" href="/static/vendors/parsons/parsons.css"/>
-    <link rel="stylesheet" href="/static/css/prettify.css"/>
 {% endblock %}
-hi! what?
 {% block base_content %}
         <h2>Required Problems</h2>
         <ul class="list-group" id="required-list"></ul>
@@ -26,7 +24,6 @@ hi! what?
         fetch('/get_problems')
             .then(response => response.json())
             .then(({required, optional}) => {
-                console.log("required is", required)
                 required['names'].map((name, index) => {
                     const link = document.createElement("a");
                     link.appendChild(document.createTextNode(name));

--- a/parsons/templates/parsons.html
+++ b/parsons/templates/parsons.html
@@ -1,11 +1,6 @@
 {% extends 'base_problem.html' %}
 {% block css %}
     <link rel="stylesheet" href="/static/vendors/parsons/parsons.css"/>
-    <!-- 
-    <link rel="stylesheet" href= "{{ url_for('static',filename='vendors/parsons/parsons.css') }}"/>
-    <link rel="stylesheet" href= "{{ url_for('static',filename='css/prettify.css') }}"/>  -->
-    <link rel="stylesheet" href="/static/css/prettify.css"/>
-
     <style type="text/css">
     .line-number {
         float: right !important;
@@ -96,7 +91,6 @@
     <script src="/static/js/jquery-3.3.1.min.js"></script>
     <script src="/static/js/jquery-ui.js"></script>
     <script src="/static/js/jquery.ui.touch-punch.min.js"></script>
-    <script src="/static/js/prettify.js"></script>
     <script src="/static/js/skulpt.js"></script>
     <script src="/static/js/skulpt-stdlib.js"></script>
     <script src="/static/js/underscore-min.js"></script>


### PR DESCRIPTION
Removes prettify.js and prettify.css from the templates we use, due to it messing up when it saw < or > inside an input.

Without prettify:
<img width="1119" alt="Screen Shot 2022-01-21 at 9 22 50 PM" src="https://user-images.githubusercontent.com/297042/150626131-e2b0d78b-0d4a-43f2-aced-9c8caa24253c.png">

We can find a prettify replacement if desired in future. Prettify is an older library that's now deprecated so it'd be better to use something like highlightJS which is still supported.
