### PR TITLE
Fix werkzeug error

### DIFF
--- a/parsons/local_server.py
+++ b/parsons/local_server.py
@@ -386,7 +386,6 @@ def run_server(port):
     # disable flask logging
     log = logging.getLogger('werkzeug')
     log.setLevel(logging.ERROR)
-    os.environ['WERKZEUG_RUN_MAIN'] = 'true'
     for port in range(PORT, PORT + 10):
         try:
             PORT = port


### PR DESCRIPTION
After 61A upgraded its Flask versions, the parsons server no longer starts due to an error described here:

https://github.com/cs01/gdbgui/issues/425

The recommendation is to not use the os.environ override hack:
https://github.com/cs01/gdbgui/issues/425#issuecomment-1086871191

There are other ways to achieve the same thing, but for now, I am just removing the line entirely, since students can't use parsons at all right now (and some students are working on late assignments).